### PR TITLE
changing handle.net identifiers to doi.org

### DIFF
--- a/isaw-papers-1/isaw-papers-1.xhtml
+++ b/isaw-papers-1/isaw-papers-1.xhtml
@@ -40,7 +40,7 @@
  <link rel="dcterms:isPartOf" href="http://www.worldcat.org/oclc/756047783" />
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />
- <link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/k98sf96r"/>
+ <link rel="dcterms:hasVersion" href="http://doi.org/2333.1/k98sf96r"/>
 
  <link rel="stylesheet" href="isaw-papers.css" />
 

--- a/isaw-papers-10/isaw-papers-10.xhtml
+++ b/isaw-papers-10/isaw-papers-10.xhtml
@@ -33,7 +33,7 @@
  <meta name="DCTERMS.license" content="Creative Commons Attribution 3.0 Unported (CC-BY)" />
  <meta name="DCTERMS.bibliographicCitation" content="S. Heath, J.L. Rife, J.J. Bravo III, and G. Blasdel. (2015). Preliminary Report on Early Byzantine Pottery from a Building Complex at Kenchreai (Greece). ISAW Papers, 10." />
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
- <link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/q83bk6k7"/>
+ <link rel="dcterms:hasVersion" href="http://doi.org/2333.1/q83bk6k7"/>
 
 </head>
 <body>

--- a/isaw-papers-12/isaw-papers-12.xhtml
+++ b/isaw-papers-12/isaw-papers-12.xhtml
@@ -39,7 +39,7 @@
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />
 
 <link rel="stylesheet" href="isaw-publications.css"/>
-<link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/brv15m2n"/>
+<link rel="dcterms:hasVersion" href="http://doi.org/2333.1/brv15m2n"/>
 <style scoped="scoped">
 
 .textparagraph {

--- a/isaw-papers-2/isaw-papers-2.xhtml
+++ b/isaw-papers-2/isaw-papers-2.xhtml
@@ -30,7 +30,7 @@
   <meta name="DC.creator" content="Andrew Meadows"/> 
   <meta name="DC.language" content="en"/> 
   <meta name="DC.publisher" content="Institute for the Study of the Ancient World, New York University"/> 
-  <link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/9s4mw84w"/>
+  <link rel="dcterms:hasVersion" href="http://doi.org/2333.1/9s4mw84w"/>
 
   <link rel="stylesheet" href="isaw-papers.css"/>
   <style type="text/css">

--- a/isaw-papers-3/isaw-papers-3.xhtml
+++ b/isaw-papers-3/isaw-papers-3.xhtml
@@ -31,7 +31,7 @@
  <meta name="DCTERMS.isPartOf" content="ISAW Papers" />
  <meta name="DC.subject" content="Delos Island (Greece)" />
  <meta name="DC.subject" content="Economic history--To 500" />
- <link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/280gb73f" />
+ <link rel="dcterms:hasVersion" href="http://doi.org/2333.1/280gb73f" />
         
 <head>
   <title>Gilles Bransbourg. "Rome and the Economic Integration of Empire" ISAW Papers 3. (2012).</title>

--- a/isaw-papers-4/isaw-papers-4.xhtml
+++ b/isaw-papers-4/isaw-papers-4.xhtml
@@ -43,7 +43,7 @@
  <link rel="dcterms:isPartOf" href="urn:issn:2164-1471" />
  <link rel="dcterms:isPartOf" href="http://isaw.nyu.edu/publications/isaw-papers" />
 
-<link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/xgxd26r7" />
+<link rel="dcterms:hasVersion" href="http://doi.org/2333.1/xgxd26r7" />
 
 <link rel="stylesheet" href="isaw-papers.css"/>
 

--- a/isaw-papers-5/isaw-papers-5.xhtml
+++ b/isaw-papers-5/isaw-papers-5.xhtml
@@ -9,7 +9,7 @@
  <title>A. McCollum. (2012). “A Syriac Fragment from ‘The Cause of All Causes’ on the Pillars of Hercules.” ISAW Papers 5.</title>
  <link rel="stylesheet" href="isaw-papers.css" />
  <link rel="dcterms:creator" href="http://viaf.org/viaf/96743024"/>
- <link rel="dcterms:hasVersion" href="http://hdl.handle.net/2333.1/j9kd5302" />
+ <link rel="dcterms:hasVersion" href="http://doi.org/2333.1/j9kd5302" />
  <link rel="dcterms:isPartOf" resource="http://isaw.nyu.edu/publications/isaw-papers" />
 </head>
 <body>

--- a/isaw-papers-8/isaw-papers-8.xhtml
+++ b/isaw-papers-8/isaw-papers-8.xhtml
@@ -28,7 +28,7 @@
 <h2>ISAW Papers 8 (2014)</h2>
 <h1 property="dcterms:title">Ivory from Muziris<sup><a id="footnote-reference-asterix" href="#footnote-asterix">*</a></sup></h1>
 <h2><span rel="dcterms:creator"><a rel="dcterms:identifier" href="http://viaf.org/viaf/92821505" property="foaf:name">Federico De Romanis</a></span></h2>
-<p class="handle"><a rel="bibo:identifier" href="http://hdl.handle.net/2333.1/p5hqc1c7">http://hdl.handle.net/2333.1/p5hqc1c7</a></p>
+<p class="handle"><a rel="bibo:identifier" href="http://doi.org/2333.1/p5hqc1c7">http://hdl.handle.net/2333.1/p5hqc1c7</a></p>
 <p id="abstract"><em>Abstract:</em><span property="dcterms:abstract"> The extant portion of the verso side of the “Muziris papyrus” (PVindob G 40822 v = SB XVIII 13617 v) contains the monetary evaluation of three-quarters of an Indian cargo loaded on the ship <i>Hermapollon</i>. Among the commodities are 167 elephant tusks weighing 3,228.5 kgs and <i>schidai</i> weighing 538.5 kgs. It is argued that <i>schidai</i> are fragments of tusks trimmed away from captive elephants. A comparison with commercial ivory lots of the early sixteenth century shows the selected quality of the tusks loaded on the <i>Hermapollon</i>.</span></p>
 <p class="subjects"><em>Subjects:</em> India--Relations--Rome, <a href="http://id.loc.gov/authorities/subjects/sh87002521">Ivory industry</a>, <a href="http://id.loc.gov/authorities/subjects/sh85040818">Economic history--to 500</a>.</p> 
 </header>


### PR DESCRIPTION
Isaw-papers 6, 7, 9, 11 and 13 did not have any handle identifiers. 